### PR TITLE
Cutoffs

### DIFF
--- a/src/computed.rs
+++ b/src/computed.rs
@@ -1,4 +1,4 @@
-use crate::engine::{self, Computable, ComputablePtr, Engine};
+use crate::engine::{self, Computable, ComputablePtr, Engine, AsPtr};
 use std::{
     cell::{Ref, RefCell},
     collections::HashSet,
@@ -70,10 +70,6 @@ impl<T: 'static> ComputedInner<T> {
                 self.value = Some((self.compute)());
             });
         }
-    }
-
-    fn as_ptr(&self) -> ComputablePtr {
-        ComputablePtr::new(self)
     }
 }
 

--- a/src/cutoff.rs
+++ b/src/cutoff.rs
@@ -1,0 +1,4 @@
+//! Idea: Computed values don't destroy their stored values, but instead just mark them as invalid.
+//! And then cutoff points can be introduced to the graph where recomputation stops when the result
+//! is equal to the previous value.
+

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -38,6 +38,16 @@ pub trait Computable {
     fn remove_reader(&mut self, reader: ComputablePtr);
 }
 
+pub trait AsPtr {
+    fn as_ptr(&self) -> ComputablePtr;
+}
+
+impl<T: Computable> AsPtr for T {
+    fn as_ptr(&self) -> ComputablePtr {
+        ComputablePtr::new(self)
+    }
+}
+
 /// This holds a pointer to a computable by preserving identity (trait objects can't be compared
 /// equality because their vtable pointer is not stable).
 #[repr(transparent)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -38,13 +38,21 @@ pub trait Computable {
     fn remove_reader(&mut self, reader: ComputablePtr);
 }
 
-pub trait AsPtr {
+pub trait Helper {
     fn as_ptr(&self) -> ComputablePtr;
+    fn remove_from_dependencies(&self, dependencies: &Dependencies);
 }
 
-impl<T: Computable> AsPtr for T {
+impl<T: Computable> Helper for T {
     fn as_ptr(&self) -> ComputablePtr {
         ComputablePtr::new(self)
+    }
+
+    fn remove_from_dependencies(&self, dependencies: &Dependencies) {
+        let self_ptr = self.as_ptr();
+        for dependency in dependencies {
+            unsafe { dependency.clone().as_mut() }.remove_reader(self_ptr);
+        }
     }
 }
 
@@ -78,6 +86,7 @@ impl ComputablePtr {
     }
 }
 
+pub type Dependencies = HashSet<ComputablePtr>;
 pub type Readers = HashSet<ComputablePtr>;
 
 // Invalidate all readers (Invoking `invalidate()` on readers may call `remove_reader()` on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod computed;
+mod cutoff;
 mod engine;
 mod var;
 

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,6 +1,6 @@
 use crate::{
     computed::Computed,
-    engine::{self, Computable, ComputablePtr, Engine, AsPtr},
+    engine::{self, Computable, ComputablePtr, Engine, Helper},
 };
 use std::{
     cell::{Ref, RefCell},

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,6 +1,6 @@
 use crate::{
     computed::Computed,
-    engine::{self, Computable, ComputablePtr, Engine},
+    engine::{self, Computable, ComputablePtr, Engine, AsPtr},
 };
 use std::{
     cell::{Ref, RefCell},
@@ -74,12 +74,6 @@ struct VarInner<T: 'static> {
     engine: Rc<Engine>,
     value: T,
     readers: engine::Readers,
-}
-
-impl<T: 'static> VarInner<T> {
-    fn as_ptr(&self) -> ComputablePtr {
-        ComputablePtr::new(self)
-    }
 }
 
 impl<T: 'static> Computable for VarInner<T> {


### PR DESCRIPTION
Preserve all computed values, separate invalidation from re-computation, and introduce cut-offs: Points in the graph that put a stop the re-computation if the result did not change, and if computed nodes find that there are only invalidated cut-off dependencies on re-evaluation, they don't re-compute either and consider themselves "cut-off" points. 

This needs a `PartialEq` bound only on the results of the cut-offs and not on the computed values. Semantic should be equivalent compared to a parameter-based memoization.

Complicates `Computed` nodes a little in that - after all dependencies have been re-computed, the evaluation trace of the immediate dependencies must somehow show if re-validated dependencies actually have changed. But this could be a simple flag maintained in the context of the evaluation.

🤔 replun flushes the dependencies on invalidation, but we can delay the cleanup until a re-evaluation starts (I guess), so that we don't have to do the computation. This makes the algorithm fairly similar to memoization (where all dependent values are kept and compared before running the computation). But the difference is that if we _compare_ only at cut-off points we don't have to compare computed results which are usually a lot more difficult to compare. Manually deciding where to put them should be obvious, and if not, it should be possible to add instrumentation to see where it makes sense (or feed evaluation patterns into some 🤖 ). 

🤔 There is always the possibility to separate evaluation spaces, for example do all the parameterization in one where it's cheap to compare values, and then feed them (using `Var::set`) into another one that does the more complicated computations. "Cheap to compare" usually also means that values are small (in size) and computation is performant.

Anyways, this sounds simple enough for experimenting with.

Requirements:
- Every node needs to expose some kind of actually change flag (or version number?)
- Cutoff nodes decide that based on comparison of the result.
- Computed nodes need to find out based on this information if they actually have to execute the computation to validate.

Note to self: Need to a take a closer look on what Adapton does.
