### PR TITLE
Hold dependencies in memory as long they are referred to.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "cSpell.words": [
+        "Acar",
+        "Adapton",
+        "incrementalized",
+        "janestreet",
+        "Leptos",
+        "Umut"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ The goal of this project is to provide a foundation for Granularity UI, A user i
 
 #### Events vs. Signal
 
-I've experimented with reactivity in user interfaces for decades. Around 2005 I've implemented most of a CSS3 layout engine based on a reactive system I wrote in C#. And after building some application on my own, the need to use event sourcing for updating and persisting state change arose, which somehow seemed incompatible with reactive primitives. So I've put the idea into a box for a while. But now I think that - with a bit of discipline and a few helpers - these two concepts can be combined just fine.
+I've experimented with reactivity in user interfaces for decades. Around 2005 I've implemented most of a CSS3 layout engine based on hierarchical attribute trees I wrote in C#. And after building some application on my own, the need to use event sourcing for updating and persisting state change arose, which somehow seemed incompatible with reactive primitives. So I've put the idea into a box for a while. But now I think that - with a bit of discipline and a few helpers - these two concepts can be combined just fine.
 
 #### Lifetime Management & Higher Order Primitives
 
-Looking and Leptos and Sycamore, I've found that there is this need to introduce a kind of evaluation / lifetime scope that bounds the lifetime of the reactive primitives. I don't know if this is a requirement, but what I need from a reactive system are just the primitives without any context or lifetime that is to care about. This is especially important when the primitives themselves need to be passed through the graph. For example, a layout engine - based on reactive primitives - may compute frame coordinates first while leaving the content primitives untouched and then passes them to the renderer which then recomputes them if needed.
+Looking and Leptos and Sycamore, I've found that there is this need to introduce a kind of evaluation / lifetime scope that bounds the lifetime of the reactive primitives. I don't know if this is a requirement, but what I need from a reactive system are just the primitives without any context or lifetime bounds that is to care about. This is especially important when the primitives themselves need to be passed through the graph. For example, a layout engine - based on reactive primitives - may compute frame coordinates first while leaving the content primitives untouched and then passes them to the renderer which then recomputes them if needed.
 
 #### Performance
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
-This experiment is a shallow dive into incremental computation. It implements a very basic, though somewhat usable automatic dependency tracking, invalidation, and recomputation system. `lib.rs`'s test cases show off a basic example on how to use it.
+This project implements an incomplete fine-grained reactivity graph. It provides rudimentary, though usable, reactive primitives, automatic dependency tracking, invalidation, and recomputation. 
 
-This implementation uses a pull / on-demand based "naive" approach for the simple reason that push-based approaches seem to be [a lot more complicated](https://www.janestreet.com/tech-talks/seven-implementations-of-incremental/) and even [semantically incorrect](https://github.com/salsa-rs/salsa/issues/41#issuecomment-589412839).
+`lib.rs`'s show cases basic examples on how to use it.
 
-A on-demand approach like in this repository suffers from too much unnecessary invalidation and re-computation and therefore needs memoization to be efficient.
+Granularity uses a pull / on-demand based "naive" approach because push-based approaches seem to be [a lot more complicated](https://www.janestreet.com/tech-talks/seven-implementations-of-incremental/) and even [semantically incorrect](https://github.com/salsa-rs/salsa/issues/41#issuecomment-589412839).
 
-If you are interested in more information about self-adjusting and incremental computation:
+### Goal
+
+The goal of this project is to provide a foundation for Granularity UI, A user interface framework that is built from reactive primitives only.
+
+### Problems To Solve
+
+#### Events vs. Signal
+
+I've experimented with reactivity in user interfaces for decades. Around 2005 I've implemented most of a CSS3 layout engine based on a reactive system I wrote in C#. And after building some application on my own, the need to use event sourcing for updating and persisting state change arose, which somehow seemed incompatible with reactive primitives. So I've put the idea into a box for a while. But now I think that - with a bit of discipline and a few helpers - these two concepts can be combined just fine.
+
+#### Lifetime Management & Higher Order Primitives
+
+Looking and Leptos and Sycamore, I've found that there is this need to introduce a kind of evaluation / lifetime scope that bounds the lifetime of the reactive primitives. I don't know if this is a requirement, but what I need from a reactive system are just the primitives without any context or lifetime that is to care about. This is especially important when the primitives themselves need to be passed through the graph. For example, a layout engine - based on reactive primitives - may compute frame coordinates first while leaving the content primitives untouched and then passes them to the renderer which then recomputes them if needed.
+
+#### Performance
+
+For now not raw performance is not a primary concern. Granularity has slightly different requirements than web frameworks, so it's probably a lot slower in the beginning, but as soon there are a number of a test cases and perhaps even a project build on top of it, it will be easier to identify bottlenecks and optimize them.
+
+Algorithmic performance is important though. Specifically the reuse of already computed values, aka memoization, needs to be solved properly and transparently to make Granularity usable.
+
+### Inspiration
+
+Here is some of the material I went through:
 
 Papers, Blog Posts, Talks:
 
@@ -19,7 +41,10 @@ Implementations (mostly Rust):
 - [Adapton: Programming Language Abstractions for Incremental Computation](http://adapton.org/)
 - [salsa-rs/salsa: A generic framework for on-demand, incrementalized computation. Inspired by adapton, glimmer, and rustc's query system.](https://github.com/salsa-rs/salsa)
 
-The name of the repository just came to me. I imagine it could be a small bird.
+Rust Web Frameworks using fine-grained reactivity:
+
+- [leptos-rs/leptos: Build fast web applications with Rust.](https://github.com/leptos-rs/leptos)
+- [sycamore-rs/sycamore: A library for creating reactive web apps in Rust and WebAssembly](https://github.com/sycamore-rs/sycamore)
 
 License: MIT
 

--- a/src/computed.rs
+++ b/src/computed.rs
@@ -114,7 +114,7 @@ impl<T: 'static> Drop for ComputedInner<T> {
         debug_assert!(self.readers.is_empty());
         let self_ptr = self.as_ptr();
         for dependency in &self.dependencies {
-            unsafe { dependency.as_mut().remove_reader(self_ptr) };
+            dependency.borrow_mut().remove_reader(self_ptr);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,8 @@ pub use var::Var;
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use crate::runtime::Runtime;
+    use std::{cell::RefCell, rc::Rc};
 
     #[test]
     fn add_two_vars() {
@@ -38,10 +37,11 @@ mod tests {
         };
         let a2 = a.share();
         let c = rt.computed(move || *a2.get() * 3);
-        let evaluation_count = RefCell::new(0);
+        let evaluation_count = Rc::new(RefCell::new(0));
         let d = {
-            rt.computed(|| {
-                *evaluation_count.borrow_mut() += 1;
+            let ec = evaluation_count.clone();
+            rt.computed(move || {
+                *ec.borrow_mut() += 1;
                 *b.get() + *c.get()
             })
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ mod tests {
             let mut a = Some(a);
             rt.computed(move || {
                 let r = *a.as_ref().unwrap().get() + *b.get();
-                // force a drop of a, even though it has readers.
+                // Drop a, even though it has readers.
                 a = None;
                 r
             })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::{computed::Computed, var::Var};
 use std::{
-    cell::{Cell, RefCell},
+    cell::{Cell, RefCell, RefMut},
     collections::HashSet,
     hash, mem, ptr,
     rc::Rc,
@@ -45,6 +45,9 @@ pub trait Computable {
 
 pub trait RefCellComputable {
     fn as_ptr(&self) -> ComputablePtr;
+
+    fn borrow_mut(&self) -> RefMut<dyn Computable>;
+
     #[allow(clippy::mut_from_ref)]
     unsafe fn as_mut(&self) -> &mut dyn Computable;
 }
@@ -55,6 +58,10 @@ where
 {
     fn as_ptr(&self) -> ComputablePtr {
         ComputablePtr::new(unsafe { &*RefCell::as_ptr(self) })
+    }
+
+    fn borrow_mut(&self) -> RefMut<dyn Computable> {
+        RefMut::map(self.borrow_mut(), |t| t as &mut dyn Computable)
     }
 
     unsafe fn as_mut(&self) -> &mut dyn Computable {
@@ -83,6 +90,10 @@ impl hash::Hash for RefCellComputableHandle {
 }
 
 impl RefCellComputableHandle {
+    pub fn borrow_mut(&self) -> RefMut<dyn Computable> {
+        self.0.borrow_mut()
+    }
+
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_mut(&self) -> &mut dyn Computable {
         self.0.as_mut()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,5 @@
 use crate::{computed::Computed, var::Var};
-use std::{cell::Cell, collections::HashSet, hash, mem, ptr, rc::Rc};
+use std::{any::Any, cell::Cell, collections::HashSet, hash, mem, ptr, rc::Rc};
 
 pub struct Runtime {
     current: Cell<Option<ComputablePtr>>,
@@ -16,7 +16,7 @@ impl Runtime {
         Var::new(self, value)
     }
 
-    pub fn computed<'a, T>(self: &Rc<Self>, compute: impl FnMut() -> T + 'a) -> Computed<'a, T> {
+    pub fn computed<T>(self: &Rc<Self>, compute: impl FnMut() -> T + 'static) -> Computed<T> {
         Computed::new(self, compute)
     }
 
@@ -34,7 +34,7 @@ impl Runtime {
 
 pub trait Computable {
     fn invalidate(&mut self);
-    fn record_dependency(&mut self, dependency: ComputablePtr);
+    fn record_dependency(&mut self, dependency: (ComputablePtr, Rc<dyn Any>));
     fn remove_reader(&mut self, reader: ComputablePtr);
 }
 


### PR DESCRIPTION
Dropping a previously _read_ dependency inside a "computation" function could cause the dependency graph to be inconsistent. This PR guarantees that the graph of dependencies is hold in memory as long there are referrers to it, even though the dependency itself got dropped.