### PR TITLE
Add streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod runtime;
 mod value;
+mod stream;
 
 pub use runtime::Runtime;
 pub use value::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 mod runtime;
-mod value;
 mod stream;
+mod value;
 
 pub use runtime::Runtime;
+pub use stream::stream;
 pub use value::Value;
 
 #[macro_export]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,79 @@
+use std::{cell::RefCell, rc::Rc};
+
+struct Stream<T> {
+    next: RefCell<Option<(T, Rc<Stream<T>>)>>,
+}
+
+impl<T> Stream<T> {
+    fn end() -> Rc<Stream<T>> {
+        Rc::new(Stream {
+            next: RefCell::new(None),
+        })
+    }
+
+    fn clone_next(&self) -> Option<(T, Rc<Stream<T>>)>
+    where
+        T: Clone,
+    {
+        let next = self.next.borrow();
+        if let Some(vn) = &*next {
+            return Some(vn.clone());
+        }
+        None
+    }
+
+    fn consume(self: &mut Rc<Self>) -> Option<T> {
+        let mut next = self.next.borrow_mut();
+        if let Some((value, next)) = &*next {
+                    }
+        None
+
+    }
+}
+
+fn stream<T>() -> (Producer<T>, Consumer<T>) {
+    let top = Stream::end();
+    (
+        Producer {
+            top: top.clone(),
+        },
+        Consumer { next: top },
+    )
+}
+
+pub struct Consumer<T> {
+    next: Rc<Stream<T>>,
+}
+
+impl<T> Clone for Consumer<T> {
+    fn clone(&self) -> Self {
+        Consumer {
+            next: self.next.clone(),
+        }
+    }
+}
+
+impl<T> Consumer<T> {
+    pub fn take(&mut self) -> Option<T>
+    where
+        T: Clone,
+    {
+        if let Some((value, next)) = self.next.clone_next() {
+            self.next = next;
+            return Some(value);
+        }
+        None
+    }
+}
+
+pub struct Producer<T> {
+    top: Rc<Stream<T>>,
+}
+
+impl<T> Producer<T> {
+    pub fn push(&mut self, value: T) {
+        let mut next = self.top.next.borrow_mut();
+        debug_assert!(next.is_none(), "Multiple producers are not supported");
+        *next = Some((value, Stream::end()));
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,17 +1,14 @@
-use std::{cell::RefCell, rc::Rc};
-
-struct Stream<T> {
-    next: RefCell<Option<(T, Rc<Stream<T>>)>>,
+use std::{cell::RefCell, iter, mem, rc::Rc};
+struct Element<T> {
+    next: RefCell<Option<(T, Rc<Element<T>>)>>,
 }
 
-impl<T> Stream<T> {
-    fn end() -> Rc<Stream<T>> {
-        Rc::new(Stream {
-            next: RefCell::new(None),
-        })
+impl<T> Element<T> {
+    fn end() -> Rc<Element<T>> {
+        Rc::new(Element::default())
     }
 
-    fn clone_next(&self) -> Option<(T, Rc<Stream<T>>)>
+    fn clone_value_and_next(&self) -> Option<(T, Rc<Element<T>>)>
     where
         T: Clone,
     {
@@ -22,29 +19,46 @@ impl<T> Stream<T> {
         None
     }
 
-    fn consume(self: &mut Rc<Self>) -> Option<T> {
-        let mut next = self.next.borrow_mut();
-        if let Some((value, next)) = &*next {
-                    }
-        None
-
+    fn into_inner(self) -> Option<(T, Rc<Element<T>>)> {
+        self.next.into_inner()
     }
 }
 
-fn stream<T>() -> (Producer<T>, Consumer<T>) {
-    let top = Stream::end();
-    (
-        Producer {
-            top: top.clone(),
-        },
-        Consumer { next: top },
-    )
+impl<T> Default for Element<T> {
+    fn default() -> Self {
+        Element {
+            next: RefCell::new(None),
+        }
+    }
+}
+
+pub fn stream<T>() -> (Producer<T>, Consumer<T>) {
+    let top = Element::end();
+    (Producer { top: top.clone() }, Consumer { next: top })
+}
+
+/// A producer points to the consuming end element of the stream.
+pub struct Producer<T> {
+    top: Rc<Element<T>>,
+}
+
+impl<T> Producer<T> {
+    pub fn produce(&mut self, value: T) {
+        let new_end = Element::end();
+        {
+            let mut next = self.top.next.borrow_mut();
+            debug_assert!(next.is_none(), "Multiple producers are not supported");
+            *next = Some((value, new_end.clone()));
+        }
+        self.top = new_end;
+    }
 }
 
 pub struct Consumer<T> {
-    next: Rc<Stream<T>>,
+    next: Rc<Element<T>>,
 }
 
+/// Custom implementation of Clone for Consumer<T> to avoid putting a Clone requirement on T.
 impl<T> Clone for Consumer<T> {
     fn clone(&self) -> Self {
         Consumer {
@@ -54,11 +68,28 @@ impl<T> Clone for Consumer<T> {
 }
 
 impl<T> Consumer<T> {
-    pub fn take(&mut self) -> Option<T>
+    pub fn drain(&mut self) -> impl Iterator<Item = T> + '_
     where
         T: Clone,
     {
-        if let Some((value, next)) = self.next.clone_next() {
+        iter::from_fn(|| self.drain_one())
+    }
+
+    pub fn drain_one(&mut self) -> Option<T>
+    where
+        T: Clone,
+    {
+        if let Some(next) = Rc::get_mut(&mut self.next) {
+            // We are the only owner of next, so we can consume it.
+            if let Some((value, next)) = mem::take(next).into_inner() {
+                self.next = next;
+                return Some(value);
+            }
+            // Consumed an end, which means that there were no producers anymore.
+            return None;
+        }
+
+        if let Some((value, next)) = self.next.clone_value_and_next() {
             self.next = next;
             return Some(value);
         }
@@ -66,14 +97,66 @@ impl<T> Consumer<T> {
     }
 }
 
-pub struct Producer<T> {
-    top: Rc<Stream<T>>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl<T> Producer<T> {
-    pub fn push(&mut self, value: T) {
-        let mut next = self.top.next.borrow_mut();
-        debug_assert!(next.is_none(), "Multiple producers are not supported");
-        *next = Some((value, Stream::end()));
+    #[test]
+    fn empty_stream() {
+        let (mut producer, mut consumer) = stream();
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), []);
+        producer.produce(1);
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1]);
+    }
+
+    #[test]
+    fn test_stream() {
+        let (mut producer, mut consumer) = stream();
+        producer.produce(1);
+        producer.produce(2);
+        producer.produce(3);
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_stream_clone() {
+        let (mut producer, mut consumer) = stream();
+        producer.produce(1);
+        producer.produce(2);
+        producer.produce(3);
+        let mut consumer2 = consumer.clone();
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1, 2, 3]);
+        assert_eq!(consumer2.drain().collect::<Vec<_>>(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn clone_after_drain() {
+        let (mut producer, mut consumer) = stream();
+        producer.produce(1);
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1]);
+        let mut consumer2 = consumer.clone();
+        producer.produce(2);
+        assert_eq!(consumer2.drain().collect::<Vec<_>>(), [2]);
+    }
+
+    #[test]
+    fn test_stream_clone_in_flight() {
+        let (mut producer, mut consumer) = stream();
+        producer.produce(1);
+        let mut consumer2 = consumer.clone();
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1]);
+        producer.produce(2);
+        assert_eq!(consumer2.drain().collect::<Vec<_>>(), [1, 2]);
+    }
+
+    #[test]
+    fn test_production_after_drain() {
+        let (mut producer, mut consumer) = stream();
+        producer.produce(1);
+        producer.produce(2);
+        producer.produce(3);
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [1, 2, 3]);
+        producer.produce(4);
+        assert_eq!(consumer.drain().collect::<Vec<_>>(), [4]);
     }
 }


### PR DESCRIPTION
To implement collections that are maintained through a granularity node network efficiently, event streams with multiple consumers need to be implemented.

The idea is to use simple chain links consumers can attach to and let reference counting take care of unreferenced links. 

Somehow this reminds me of how ribosomes work.