### PR TITLE
Support multiple get_ref()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,4 +277,19 @@ mod tests {
         assert_eq!(c.get(), 2);
         assert_eq!(count.get(), 1);
     }
+
+    // Two references (retrieved with `get_ref()`) to the same value must be able to exist at the
+    // same time.
+    #[test]
+    fn two_get_refs() {
+        let rt = Runtime::new();
+        let a = rt.var(1);
+        // 'b' is evaluated second and retrieves another reference to `a`
+        let b = map_ref!(|a| *a);
+        // 'r' is evaluated first and keeps a reference to `a` and then evaluates `b`.
+        let r = map_ref!(|a, b| a + b);
+        assert_eq!(r.get(), 2);
+        // And `a` must be read twice.
+        assert_eq!(a.readers_count(), 2);
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,6 @@
 use crate::runtime::{self, Node, NodePtr, RefCellNode, RefCellNodeHandle, Runtime};
 use std::{
     cell::{Ref, RefCell},
-    collections::HashSet,
     mem,
     rc::Rc,
 };
@@ -23,7 +22,7 @@ impl<T> Value<T> {
     pub(crate) fn new_var(runtime: &Rc<Runtime>, value: T) -> Self {
         let inner = ValueInner {
             runtime: runtime.clone(),
-            readers: HashSet::new(),
+            readers: Default::default(),
             primitive: Var(value),
         };
         Value(Rc::new(RefCell::new(inner)))
@@ -35,7 +34,7 @@ impl<T> Value<T> {
     ) -> Self {
         let inner = ValueInner {
             runtime: runtime.clone(),
-            readers: HashSet::new(),
+            readers: Default::default(),
             primitive: Computed {
                 value: None,
                 compute: Box::new(compute),
@@ -57,7 +56,7 @@ impl<T> Value<T> {
 
     /// Evaluates the value and returns a reference to the contained value.
     pub fn get_ref(&self) -> Ref<T> {
-        self.ensure_valid_and_track();
+        self.ensure_valid_and_track_read();
         let r = self.0.borrow();
         Ref::map(r, |r| r.primitive.value().unwrap())
     }
@@ -83,21 +82,24 @@ impl<T> Value<T> {
         self.0.borrow().runtime.clone()
     }
 
-    fn ensure_valid_and_track(&self) {
+    fn ensure_valid_and_track_read(&self) {
         let inner = self.0.try_borrow_mut();
         let Ok(mut inner) = inner else {
             // `inner` is already borrowed, this means that there are another `get_ref()` is active,
             // or there is a cycle in the evaluation. The former is fine if the value is valid.
             let inner = self.0.borrow();
             debug_assert!(inner.is_valid());
-
+            self.track_read(&inner);
             return;
         };
         inner.ensure_valid();
+        self.track_read(&inner);
+    }
 
+    fn track_read(&self, inner: &ValueInner<T>) {
         let reader = inner.runtime.current();
         if let Some(mut reader) = reader {
-            inner.readers.insert(reader);
+            inner.readers.borrow_mut().insert(reader);
 
             let reader = unsafe { reader.as_mut() };
             reader.track_read_from(self.0.clone());
@@ -111,7 +113,7 @@ impl<T> Value<T> {
 
     #[cfg(test)]
     pub(crate) fn readers_count(&self) -> usize {
-        self.0.borrow().readers.len()
+        self.0.borrow().readers.borrow().len()
     }
 }
 
@@ -119,7 +121,10 @@ struct ValueInner<T: 'static> {
     runtime: Rc<Runtime>,
     // The nodes that read from this node. Nodes reading from this node are responsible for removing
     // themselves from us in their drop implementation.
-    readers: runtime::Readers,
+    //
+    // Note that readers _must_ be stored in a `RefCell`, because there might be existing references
+    // (retrieved via `get_ref()`) already existing at the time new readers are added. See #8.
+    readers: RefCell<runtime::Readers>,
     primitive: Primitive<T>,
 }
 
@@ -187,7 +192,7 @@ impl<T> ValueInner<T> {
             } => {
                 if value.is_none() {
                     // Readers must be empty when recomputing.
-                    assert!(self.readers.is_empty());
+                    debug_assert!(self.readers.borrow().is_empty());
                     self.runtime.eval(self_ptr, || {
                         *value = Some(compute());
                     });
@@ -217,15 +222,23 @@ impl<T> Node for ValueInner<T> {
         //
         // TODO: Validate this behavior by creating a test case that checks the drop order.
         {
-            let mut readers = mem::take(&mut self.readers);
+            // TODO: Can't borrow readers here while propagating the invalidation, because we might
+            // be called from a reader that wants to remove itself.
+            //
+            // This might be simplified by using an invalidation context that guarantees that
+            // readers are only removed once.
+            let mut readers = mem::take(&mut *self.readers.borrow_mut());
             for reader in &readers {
                 unsafe { reader.clone().as_mut() }.invalidate();
             }
-            // Readers in this instance not allowed to change while invalidation runs.
-            debug_assert!(self.readers.is_empty());
-            // Clear the readers and put it back to keep the capacity.
+            // Clear the readers
             readers.clear();
-            self.readers = readers;
+
+            // Put the empty ones back to keep the capacity
+            let self_readers = &mut *self.readers.borrow_mut();
+            // Readers in this instance not allowed to change while invalidation runs.
+            debug_assert!(self_readers.is_empty());
+            *self_readers = readers;
         };
 
         // Clean up this value last
@@ -261,13 +274,14 @@ impl<T> Node for ValueInner<T> {
     }
 
     fn remove_reader(&mut self, reader: NodePtr) {
-        self.readers.remove(&reader);
+        // TODO: Now that `borrow_mut()` is used here, remove_reader() can use `&self`.
+        self.readers.borrow_mut().remove(&reader);
     }
 }
 
 impl<T> Drop for ValueInner<T> {
     fn drop(&mut self) {
-        debug_assert!(self.readers.is_empty());
+        debug_assert!(self.readers.borrow().is_empty());
 
         // TODO: `self_ptr` is only used in the `Computed` path.
         let self_ptr = self.as_ptr();


### PR DESCRIPTION
When multiple get_ref() / Ref<T> to the same value exist, borrowing `inner` mutable is not possible, which means that `readers` can't be updated.

The most pragmatic way is to wrap the set of readers in another RefCell.