### PR TITLE
Integrate Stream with Value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 mod runtime;
 mod stream;
+mod stream_value;
 mod value;
 
 pub use runtime::Runtime;
-pub use stream::stream;
+pub use stream_value::*;
 pub use value::Value;
 
 #[macro_export]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,6 +10,7 @@ pub fn producer<T>() -> Producer<T> {
     Producer { top }
 }
 
+#[allow(unused)]
 pub fn stream<T>() -> (Producer<T>, Consumer<T>) {
     let producer = producer();
     let consumer = producer.subscribe();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,28 +1,19 @@
 use std::{cell::RefCell, iter, mem, rc::Rc};
 
-use crate::Value;
-
-//
-// Value Integration
-//
-
-impl<T> Value<Producer<T>> {
-    pub fn produce(&mut self, value: T) {
-        self.apply(|mut p| {
-            p.produce(value);
-            p
-        })
-    }
-}
-
 //
 // Implementation
 //
 
 /// Create a single producer, multiple consumer stream.
-pub fn stream<T>() -> (Producer<T>, Consumer<T>) {
+pub fn producer<T>() -> Producer<T> {
     let top = Element::end();
-    (Producer { top: top.clone() }, Consumer { next: top })
+    Producer { top }
+}
+
+pub fn stream<T>() -> (Producer<T>, Consumer<T>) {
+    let producer = producer();
+    let consumer = producer.subscribe();
+    (producer, consumer)
 }
 
 /// A producer points to the consuming end element of the stream.
@@ -31,6 +22,12 @@ pub struct Producer<T> {
 }
 
 impl<T> Producer<T> {
+    pub fn subscribe(&self) -> Consumer<T> {
+        Consumer {
+            next: self.top.clone(),
+        }
+    }
+
     pub fn produce(&mut self, value: T) {
         let new_end = Element::end();
         {

--- a/src/stream_value.rs
+++ b/src/stream_value.rs
@@ -1,0 +1,52 @@
+use std::{cell::RefCell, iter, rc::Rc};
+
+use crate::{stream, Value};
+
+/// A producer value. Use produce() to produce new values, and subscribe(), to subscribe to a
+/// produce and return a consumer. The consumer receivers all new values that are produced by the
+/// producer.
+pub type Producer<T> = Value<stream::Producer<T>>;
+// TODO: There should be Value that preserves its value on invalidation, and the compute function
+// should take the old value (if existing). This way we could remove the reference counter here.
+pub type Consumer<T> = Value<ConsumerValue<T>>;
+
+impl<T> Producer<T> {
+    pub fn subscribe(&self) -> Consumer<T> {
+        let producer = self.get_ref();
+        let consumer = ConsumerValue::new(producer.subscribe());
+        let producer = self.clone();
+        self.runtime().computed(move || {
+            producer.track();
+            consumer.clone()
+        })
+    }
+
+    pub fn produce(&mut self, value: T) {
+        self.apply(|mut p| {
+            p.produce(value);
+            p
+        })
+    }
+}
+
+pub struct ConsumerValue<T>(Rc<RefCell<stream::Consumer<T>>>);
+
+impl<T> Clone for ConsumerValue<T> {
+    fn clone(&self) -> Self {
+        ConsumerValue(self.0.clone())
+    }
+}
+
+impl<T> ConsumerValue<T> {
+    pub fn new(consumer: stream::Consumer<T>) -> Self {
+        ConsumerValue(Rc::new(RefCell::new(consumer)))
+    }
+
+    pub fn drain(&self) -> impl Iterator<Item = T> + '_
+    where
+        T: Clone,
+    {
+        let mut consumer = self.0.borrow_mut();
+        iter::from_fn(move || consumer.drain_one())
+    }
+}

--- a/src/stream_value.rs
+++ b/src/stream_value.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, iter, rc::Rc};
 
-use crate::{stream, Value};
+use crate::{stream, Runtime, Value};
 
 /// A producer value. Use produce() to produce new values, and subscribe(), to subscribe to a
 /// produce and return a consumer. The consumer receivers all new values that are produced by the
@@ -9,6 +9,13 @@ pub type Producer<T> = Value<stream::Producer<T>>;
 // TODO: There should be Value that preserves its value on invalidation, and the compute function
 // should take the old value (if existing). This way we could remove the reference counter here.
 pub type Consumer<T> = Value<ConsumerValue<T>>;
+
+impl Runtime {
+    pub fn producer<T>(&self) -> Producer<T> {
+        let producer = stream::producer();
+        self.var(producer)
+    }
+}
 
 impl<T> Producer<T> {
     pub fn subscribe(&self) -> Consumer<T> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -58,6 +58,11 @@ impl<T> Value<T> {
         Ref::map(r, |r| r.primitive.value().unwrap())
     }
 
+    /// Track the value for receiving change notifications when it changes.
+    pub fn track(&self) {
+        self.ensure_valid_and_track_read();
+    }
+
     /// Makes sure the value is evaluated then takes it out and invalidates it.
     ///
     /// This can't be called inside a evaluation context.


### PR DESCRIPTION
This PR attempts to integrate stream with Value<T> so that streams can be used seamlessly together.

- Whenever a Value contains a `Producer<T>` provide a function `produce(value: T)`.
- Whenever a Value contains a `Consumer<T>` provide a function `drain()`.
