### PR TITLE
Proc macro

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
         "Leptos",
         "Punct",
         "Umut"
-    ],
-    "rust-analyzer.showUnlinkedFileNotification": false
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,8 @@
         "incrementalized",
         "janestreet",
         "Leptos",
+        "Punct",
         "Umut"
-    ]
+    ],
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 replace_with = "0.1.7"
+granularity_macros = { path = "macros" }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "granularity_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.30"
+quote = "1.0.32"
+syn = { version = "2.0.27", features = ["full"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,9 +1,14 @@
 use proc_macro::TokenStream;
 
 mod map;
-
+mod memo;
 
 #[proc_macro]
 pub fn map(input: TokenStream) -> TokenStream {
     map::map(input)
+}
+
+#[proc_macro]
+pub fn memo(input: TokenStream) -> TokenStream {
+    memo::memo(input)
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,9 @@
+use proc_macro::TokenStream;
+
+mod map;
+
+
+#[proc_macro]
+pub fn map(input: TokenStream) -> TokenStream {
+    map::map(input)
+}

--- a/macros/src/map.rs
+++ b/macros/src/map.rs
@@ -1,0 +1,80 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse2, parse_macro_input,
+    punctuated::Punctuated,
+    Expr, Ident, Result, Token,
+};
+
+enum ArgType {
+    Reference,
+    Value,
+}
+
+struct Arg {
+    ty: ArgType,
+    ident: Ident,
+}
+
+impl Parse for Arg {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ty = if input.peek(Token![&]) {
+            input.parse::<Token![&]>()?;
+            ArgType::Reference
+        } else {
+            ArgType::Value
+        };
+        let ident = input.parse()?;
+        Ok(Arg { ty, ident })
+    }
+}
+
+struct Map {
+    args: Vec<Arg>,
+    body: Expr,
+}
+
+impl Parse for Map {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<Token! {|}>()?;
+        let args = Punctuated::<Arg, Token![,]>::parse_separated_nonempty(input)?;
+        input.parse::<Token! {|}>()?;
+        let body = input.parse()?;
+        Ok(Map {
+            args: args.into_iter().collect(),
+            body,
+        })
+    }
+}
+
+pub fn map(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input);
+    let output: proc_macro2::TokenStream = { map_int(input) };
+    proc_macro::TokenStream::from(output)
+}
+
+pub fn map_int(input: TokenStream) -> TokenStream {
+    let map: Map = parse2(input).unwrap();
+    let identifiers: Vec<_> = map.args.iter().map(|a| &a.ident).collect();
+    let first = &map.args.first().unwrap().ident;
+    let getters = map.args.iter().map(|a| {
+        let ident = &a.ident;
+        match a.ty {
+            ArgType::Reference => quote! { &*#ident.get_ref() },
+            ArgType::Value => quote! { #ident.get() },
+        }
+    });
+    let body = &map.body;
+
+    quote! {
+        {
+            #(let #identifiers = #identifiers.clone();)*
+            #first.runtime().computed(move || {
+                #(let #identifiers = #getters;)*
+                #body
+            })
+        }
+    }
+}
+

--- a/macros/src/map.rs
+++ b/macros/src/map.rs
@@ -77,4 +77,3 @@ pub fn map_int(input: TokenStream) -> TokenStream {
         }
     }
 }
-

--- a/macros/src/memo.rs
+++ b/macros/src/memo.rs
@@ -1,0 +1,58 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse2, parse_macro_input,
+    punctuated::Punctuated,
+    Expr, Ident, Result, Token,
+};
+
+struct Memo {
+    args: Vec<Ident>,
+    body: Expr,
+}
+
+impl Parse for Memo {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<Token! {|}>()?;
+        let args = Punctuated::<Ident, Token![,]>::parse_separated_nonempty(input)?;
+        input.parse::<Token! {|}>()?;
+        let body = input.parse()?;
+        Ok(Memo {
+            args: args.into_iter().collect(),
+            body,
+        })
+    }
+}
+
+pub fn memo(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input);
+    let output: proc_macro2::TokenStream = { map_int(input) };
+    proc_macro::TokenStream::from(output)
+}
+
+pub fn map_int(input: TokenStream) -> TokenStream {
+    let map: Memo = parse2(input).unwrap();
+    let identifiers: Vec<_> = map.args.iter().collect();
+    let first = &map.args.first();
+    let getters: Vec<_> = map
+        .args
+        .iter()
+        .map(|ident| {
+            quote! { #ident.get() }
+        })
+        .collect();
+    let body = &map.body;
+
+    quote! {
+        {
+            #(let #identifiers = #identifiers.clone();)*
+            #first.runtime().memo(
+                move || (#(#getters,)*)
+                ,
+                move |(#(#identifiers,)*)| {
+                #body
+            })
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,36 +3,14 @@ mod stream;
 mod stream_value;
 mod value;
 
-pub use granularity_macros::map;
+pub use granularity_macros::{map, memo};
 pub use runtime::Runtime;
 pub use stream_value::*;
 pub use value::Value;
 
-#[macro_export]
-macro_rules! memo {
-    (| $first:ident | $body:expr) => {{
-        let $first = $first.clone();
-        $first.runtime().memo(
-            move || $first.get(),
-            move |$first| { $body }
-        )
-    }};
-
-    (| $first:ident, $($rest:ident),* | $body:expr) => {{
-        let $first = $first.clone();
-        $(let $rest = $rest.clone();)*
-        $first.runtime().memo(
-            move || ($first.get(), $($rest.get()),*),
-            move |($first, $($rest),*)| { $body }
-        )
-
-    }}
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::map;
-    use crate::runtime::Runtime;
+    use crate::{map, memo, runtime::Runtime};
     use std::{
         cell::{Cell, RefCell},
         rc::Rc,


### PR DESCRIPTION
Convert map and memo to proc macros. Also support `&` as a valid prefix to indicate that the value should be processed as a reference inside the map macro.